### PR TITLE
fix: Run ensureNotAuthenticated when no account is given

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,8 +62,11 @@ class TemplateContentScript extends ContentScript {
     return true
   }
 
-  async ensureAuthenticated() {
+  async ensureAuthenticated(account) {
     this.log('info', 'ensureAuthenticated starts')
+    if (!account) {
+      await this.ensureNotAuthenticated()
+    }
     await this.navigateToLoginForm()
 
     if (!(await this.runInWorker('checkAuthenticated'))) {


### PR DESCRIPTION
To be sure not to run the konnector with the wrong identifiers.
