### PR TITLE
Fix/sort detailed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -174,12 +174,22 @@ class RedContentScript extends ContentScript {
     this.log('debug', 'Saving files')
     await this.saveIdentity(this.store.userIdentity)
     for (const bill of this.store.allBills) {
-      await this.saveBills([bill], {
-        context,
-        fileIdAttributes: ['filename'],
-        contentType: 'application/pdf',
-        qualificationLabel: 'phone_invoice'
-      })
+      if (bill.filename.includes('détail')) {
+        await this.saveBills([bill], {
+          context,
+          fileIdAttributes: ['filename'],
+          contentType: 'application/pdf',
+          qualificationLabel: 'phone_invoice',
+          subPath: 'Detailed Invoices'
+        })
+      } else {
+        await this.saveBills([bill], {
+          context,
+          fileIdAttributes: ['filename'],
+          contentType: 'application/pdf',
+          qualificationLabel: 'phone_invoice'
+        })
+      }
     }
   }
 


### PR DESCRIPTION
This PR aims to separate detailed bills from normal bills when saving them on the cozy.
Some times, website ask for a login confirmation when trying to reach the bills page, so it also add a check to see if the website is asking for a relogin. If it's the case, the loginForm is prefilled and we show the webview to the user so he can pass the captcha.