### PR TITLE
feat: Uncheck remember me button to stabilize logout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const log = Minilog('ContentScript')
 Minilog.enable('redCCC')
 
 const BASE_URL = 'https://www.red-by-sfr.fr'
+const SFR_CLIENT_SPACE_URL = 'https://www.sfr.fr/mon-espace-client/'
 const CLIENT_SPACE_HREF =
   'https://www.red-by-sfr.fr/mon-espace-client/?casforcetheme=espaceclientred#redclicid=X_Menu_EspaceClient'
 const PERSONAL_INFOS_URL =
@@ -57,35 +58,24 @@ class RedContentScript extends ContentScript {
 
   async ensureNotAuthenticated() {
     this.log('info', '🤖 ensureNotAuthenticated starts')
-
-    await this.navigateToLoginForm()
+    await this.goto(SFR_CLIENT_SPACE_URL)
+    await this.waitForElementInWorker('#username, label[title=Client]')
     const isSfr = await this.runInWorker('isSfrUrl')
     if (isSfr) {
       this.log('info', 'Found sfr url. Running ensureSfrNotAuthenticated')
       await this.ensureSfrNotAuthenticated()
-      await this.navigateToLoginForm()
-      return true
+      if (!(await this.isElementInWorker('#password'))) {
+        await this.navigateToLoginForm()
+      }
+    } else {
+      throw new Error(
+        'Logout failed - Cannot reach SFR page, cannot achieve logout properly'
+      )
     }
-    const authenticated = await this.runInWorker('checkAuthenticated')
-    if (!authenticated) {
-      this.log('info', 'not auth, returning true')
-      return true
-    }
-    this.log('info', 'auth detected, logging out')
-    await this.runInWorker(
-      'click',
-      'a[href*="https://www.sfr.fr/auth/realms/sfr/protocol/openid-connect/logout"]'
-    )
-    // Sometimes the logout lead you to sfr's website, or on red's loginForm, so we cover all possibilities just in case.
-    await this.waitForElementInWorker(
-      'a[href="https://www.red-by-sfr.fr/mon-espace-client/"], a[href="https://www.sfr.fr/mon-espace-client/"], #password '
-    )
-    if (!(await this.isElementInWorker('#password'))) {
-      await this.navigateToLoginForm()
-    }
+
     const authenticatedAfter = await this.runInWorker('checkAuthenticated')
     if (authenticatedAfter) {
-      throw new Error('logout failed')
+      throw new Error('Logout failed - Something went wrong after sfrLogout')
     }
     return true
   }


### PR DESCRIPTION
This PR add a function to uncheck the rememberMe button on the loginPage.

This appears to allows the logout to be more consistent, this is the only way we found to stabilize the logout a bit. We cannot clean the cookies, and retries doesn't seems to work as well as it did before. 
This might be linked to the complicated way of managing the cookies/session for both Red and SFR website

EDIT : 

It has been decided for now to use a 10 sec sleep to ensure website is ready to achieve a logout as it's the only way stable enough to do a proper logout.


This was the comment to explain why we were trying to use a sleep instead of anything else :

```
// We cannot find any other way stable enough to detects the page is ready to be logged out
    // We tried a lot of thing including : Modify navigation, modify/remove the available auth cookie (not httpOnly), changes in the navigation
    // goto on several differents urls, interceptions to watch for specifics urls or data in the network traffic, none of them is stable enough to be used.

    // NB : The website IS unstable even for lambda users, logging out on browser desktop is not always ensured too.
    // In the RED case, we are logged in via SFR, therefore some auth cookies could be on SFR's domain instead of red's
    // leading to numerous conflicts the website did not handle very well itself so the user will not be totally logged out more often than he will.
    // There is also some scenarios where we're not apparently logged in on red's homePage, but we are if we try to reach the account's homePage.
    // And vice-versa, you could appear like you are already logged in on the red's homePage, but not anymore when you try to reach an account's page (event the account homePage)
    // So for now, it has been discuss and decided that we're using the "sleep" function, as it's the only way the logout works as intended in any tested scenarios.
    // Clearly not recommended, it will be change if we finally find another way to achieve a proper detection to ensure the logout will go well.

```

EDIT 2 : 

A goto SFR website seems to stabilise a lot the logout, this way we're avoiding the multiple redirections when trying to logout from Red website
We now simply reach the account homePage but on the SFR version of the site, disconnect from here and go back to Red's