### PR TITLE
[SCR-261] fix: Fix identity format to avoid conflicts in myselfCard

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -200,7 +200,7 @@ class RedContentScript extends ContentScript {
       }
       await this.runInWorker('getBills')
       this.log('debug', 'Saving files')
-      await this.saveIdentity(this.store.userIdentity)
+      await this.saveIdentity({ contact: this.store.userIdentity })
       const detailedBills = []
       const normalBills = []
       for (const bill of this.store.allBills) {
@@ -340,7 +340,7 @@ class RedContentScript extends ContentScript {
     const homePhoneNumber = document.querySelector('#telephoneContactFixe')
     const email = document.querySelector('#emailContact').innerHTML
     const userIdentity = {
-      email,
+      email: [{ address: email }],
       name: {
         givenName,
         familyName,


### PR DESCRIPTION
Fixes identity email format that was messing with the myself card infos in MesPapiers app. We're now putting the mail adress into an array

we also send a proper contact object to saveIdentity avoiding warning logs.