### PR TITLE
[SCR-263] fix: Check visibility of personnalInfos tab

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -139,6 +139,20 @@ class RedContentScript extends ContentScript {
   async getUserDataFromWebsite() {
     this.log('info', '🤖 getUserDataFromWebsite starts')
     await this.waitForElementInWorker(`a[href="${PERSONAL_INFOS_URL}"]`)
+    const isVisible = await this.runInWorker(
+      'checkPersonnalInfosLinkVisibility'
+    )
+    if (!isVisible) {
+      this.log(
+        'warn',
+        'Access to personnal infos page is not allowed for this contract, skipping identity scraping'
+      )
+      const credentials = await this.getCredentials()
+      const storeLogin = this.store.userCredentials?.login
+      return {
+        sourceAccountIdentifier: credentials.login || storeLogin
+      }
+    }
     await this.runInWorker('click', `a[href="${PERSONAL_INFOS_URL}"]`)
     await Promise.race([
       this.waitForElementInWorker('#emailContact'),
@@ -200,7 +214,9 @@ class RedContentScript extends ContentScript {
       }
       await this.runInWorker('getBills')
       this.log('debug', 'Saving files')
-      await this.saveIdentity({ contact: this.store.userIdentity })
+      if (this.store.userIdentity) {
+        await this.saveIdentity({ contact: this.store.userIdentity })
+      }
       const detailedBills = []
       const normalBills = []
       for (const bill of this.store.allBills) {
@@ -868,6 +884,15 @@ class RedContentScript extends ContentScript {
     this.log('debug', 'Old bills fetched')
     return oldBills
   }
+
+  async checkPersonnalInfosLinkVisibility() {
+    this.log('info', '📍️ checkPersonnalInfosLinkVisibility starts')
+    const elementComputedStyles = window.getComputedStyle(
+      document.querySelector(`a[href="${PERSONAL_INFOS_URL}"]`)
+    )
+    const isVisible = elementComputedStyles?.display !== 'none'
+    return isVisible
+  }
 }
 
 const connector = new RedContentScript()
@@ -880,7 +905,8 @@ connector
       'getBills',
       'getIdentity',
       'waitForSfrUrl',
-      'isSfrUrl'
+      'isSfrUrl',
+      'checkPersonnalInfosLinkVisibility'
     ]
   })
   .catch(err => {


### PR DESCRIPTION
We got users not able to reach the infoPage (or fall into unknown case).

As we got the same type of problem on SFR, it might be because they are doing some changes on this side of the website. 
The elements are apparently being generated the same way SFR did, so I copy de checkPersonnalInfosLinkIsVisible function as it might be handled the same way.