### PR TITLE
[SCR-352] fix: Avoid error if no credentials for SAI saved yet

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,7 @@ class RedContentScript extends ContentScript {
       const credentials = await this.getCredentials()
       const storeLogin = this.store.userCredentials?.login
       return {
-        sourceAccountIdentifier: credentials.login || storeLogin
+        sourceAccountIdentifier: credentials?.login || storeLogin
       }
     }
     await this.runInWorker('click', `a[href="${PERSONAL_INFOS_URL}"]`)


### PR DESCRIPTION
It just add a questionMark after credentials to prevent erreor if no credentials has been saved yet