### PR TITLE
[SCR-263] fix: Avoid silent error when personnalInfosLink is not present

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -887,10 +887,19 @@ class RedContentScript extends ContentScript {
 
   async checkPersonnalInfosLinkVisibility() {
     this.log('info', '📍️ checkPersonnalInfosLinkVisibility starts')
-    const elementComputedStyles = window.getComputedStyle(
-      document.querySelector(`a[href="${PERSONAL_INFOS_URL}"]`)
+    const infoPersoElement = document.querySelector(
+      `a[href="${PERSONAL_INFOS_URL}"]`
     )
-    const isVisible = elementComputedStyles?.display !== 'none'
+    let isVisible = false
+    if (infoPersoElement) {
+      this.log('info', 'Found link')
+      const elementComputedStyles = window.getComputedStyle(infoPersoElement)
+      isVisible = elementComputedStyles?.display !== 'none'
+    }
+    this.log(
+      'info',
+      `InfosLink element is visible : ${JSON.stringify(isVisible)}`
+    )
     return isVisible
   }
 }


### PR DESCRIPTION
This PR fixes a silent error occuring when the wanted element is not present. The error was when trying to get the computedStyles of "null", leading the function to ends prematurely. I can't say for sure it will fix the linear issus linked, but at least now we're sure things works properly.