### PR TITLE
[SCR-616] feat: Remove 'telecom' categorie from manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -10,7 +10,6 @@
   "editor": "Cozy",
   "vendor_link": "https://www.red-by-sfr.fr/",
   "categories": [
-    "telecom",
     "isp"
   ],
   "folders": [


### PR DESCRIPTION
Remove telecom category from manifest to avoid displaying konnector in two separate categories in the store