### PR TITLE
[SCR-646] Fix/info page links

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,6 @@ Minilog.enable('redCCC')
 const BASE_URL = 'https://www.red-by-sfr.fr'
 const CLIENT_SPACE_HREF =
   'https://www.red-by-sfr.fr/mon-espace-client/?casforcetheme=espaceclientred#redclicid=X_Menu_EspaceClient'
-const PERSONAL_INFOS_URL =
-  'https://espace-client-red.sfr.fr/infospersonnelles/contrat/informations'
 const INFO_CONSO_URL = 'https://espace-client-red.sfr.fr/infoconso-mobile/conso'
 const MOBILE_BILLS_URL_PATH =
   '/facture-mobile/consultation#sfrintid=EC_telecom_mob-abo_mob-factpaiement'
@@ -138,11 +136,11 @@ class RedContentScript extends ContentScript {
 
   async getUserDataFromWebsite() {
     this.log('info', '🤖 getUserDataFromWebsite starts')
-    await this.waitForElementInWorker(`a[href="${PERSONAL_INFOS_URL}"]`)
-    const isVisible = await this.runInWorker(
-      'checkPersonnalInfosLinkVisibility'
+    await this.waitForElementInWorker(
+      `a[href*="//www.sfr.fr/mon-espace-client/redirect.html?e="]`
     )
-    if (!isVisible) {
+    const redMLS = await this.runInWorker('checkPersonnalInfosLinkAvailability')
+    if (!redMLS) {
       this.log(
         'warn',
         'Access to personnal infos page is not allowed for this contract, skipping identity scraping'
@@ -153,7 +151,10 @@ class RedContentScript extends ContentScript {
         sourceAccountIdentifier: credentials?.login || storeLogin
       }
     }
-    await this.runInWorker('click', `a[href="${PERSONAL_INFOS_URL}"]`)
+    await this.runInWorker(
+      'click',
+      `a[href="//www.sfr.fr/mon-espace-client/redirect.html?e=${redMLS}&U=https%3A//espace-client-red.sfr.fr/infospersonnelles/contrat/informations/%3Fred%3D1"]`
+    )
     await Promise.race([
       this.waitForElementInWorker('#emailContact'),
       this.waitForElementInWorker('#password')
@@ -885,22 +886,26 @@ class RedContentScript extends ContentScript {
     return oldBills
   }
 
-  async checkPersonnalInfosLinkVisibility() {
-    this.log('info', '📍️ checkPersonnalInfosLinkVisibility starts')
+  async checkPersonnalInfosLinkAvailability() {
+    this.log('info', '📍️ checkPersonnalInfosLinkAvailability starts')
+    // Looks like its some kind of identifier used in href's attributes for 'a' elements
+    const redMLS = document
+      .querySelector('body')
+      .innerHTML.match(/<!--MLS=.*-->/g)[0]
+      .split('MLS=')[1]
+      .replace('-->', '')
     const infoPersoElement = document.querySelector(
-      `a[href="${PERSONAL_INFOS_URL}"]`
+      `a[href="//www.sfr.fr/mon-espace-client/redirect.html?e=${redMLS}&U=https%3A//espace-client-red.sfr.fr/infospersonnelles/contrat/informations/%3Fred%3D1"]`
     )
-    let isVisible = false
     if (infoPersoElement) {
-      this.log('info', 'Found link')
-      const elementComputedStyles = window.getComputedStyle(infoPersoElement)
-      isVisible = elementComputedStyles?.display !== 'none'
+      return redMLS
+    } else {
+      this.log(
+        'info',
+        "infoPerso element not visible, can't access the info page"
+      )
+      return false
     }
-    this.log(
-      'info',
-      `InfosLink element is visible : ${JSON.stringify(isVisible)}`
-    )
-    return isVisible
   }
 }
 
@@ -915,7 +920,7 @@ connector
       'getIdentity',
       'waitForSfrUrl',
       'isSfrUrl',
-      'checkPersonnalInfosLinkVisibility'
+      'checkPersonnalInfosLinkAvailability'
     ]
   })
   .catch(err => {


### PR DESCRIPTION
This PR fixes the main user's problem when trying to find or access personnal infos page. Website changes the url in hrefs attributes, leading the konnector to throw an error on a missing element.
It also added kind on an "id" and redirection url to those urls, making in impossible to fetch with a simple querySelector. The new id ( named "MLS") can be found in the HTML of the page, so it's scraped here to be insert in the querySelector. Redirection link seems to be equal in every case so it's hardcoded for the moment.

I also notice during dev website can redirect the login request on the same url. I didn't find any reasons to this behavior but the second commit is a workaround using pWaitFor  inside  of checkAuthenticated to fill emptied inputs if detected.