### PR TITLE
[SCR-687] feat: Ensure contracts list is loaded before finding contracts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -183,7 +183,12 @@ class RedContentScript extends ContentScript {
     if (this.store.userCredentials) {
       await this.saveCredentials(this.store.userCredentials)
     }
-    await this.waitForElementInWorker(`a[href="${INFO_CONSO_URL}"]`)
+    await Promise.all([
+      this.waitForElementInWorker(
+        `a[href='https://espace-client.sfr.fr/gestion-ligne/lignes/ajouter']`
+      ),
+      this.waitForElementInWorker(`a[href="${INFO_CONSO_URL}"]`)
+    ])
     const contracts = await this.runInWorker('getContracts')
     if (
       contracts[0].text.startsWith('06') ||


### PR DESCRIPTION
This PR ensures the element used to find the actual contract name is indeed loaded. I cannot find another way to scrape it otherwise so we're trying to wait for it, as it is supposed to be here for every user because one of the contract is selected by default to lead to the home page.

We still have some issues with the logout on some users. For memory, it is a know issue, even on browser like a normal user. With the account used to dev, we still encouter it from time to time, but it's really random and still works the majority of the time. I can't find another way to ensure logout is done properly, working on cookies won't work, it has been tested in the past, again on this run, but still nothing. The way we're doing it is pretty simple, as we just click the logout button and wait for the loginForm.